### PR TITLE
Fix potential logic error in offline_sampling.md

### DIFF
--- a/arrays/offline_sampling.md
+++ b/arrays/offline_sampling.md
@@ -13,7 +13,7 @@ def offline_sampling(arr, k)
     i = 0
     result = []
     while i<k
-        r = random(i, k)
+        r = random(i, arr.size)
         result << arr[r]
         swap(arr, i, r)
         i += 1


### PR DESCRIPTION
Pulling a random number between `[i,k)` will not allow some numbers in the array to be considered in random selection giving a nonuniform distribution. Think going from`[i, arr.size)` is better. Not sure if the `random(a, b)` is inclusive on `b` or not, so just double check in case.